### PR TITLE
Fix: Modify Docker responsiveness check in setup_venv.bat

### DIFF
--- a/setup_venv.bat
+++ b/setup_venv.bat
@@ -74,9 +74,9 @@ EXIT /B 0
     )
 
     ECHO [!SCRIPT_NAME!] Docker command is accessible. Checking if Docker engine is responsive...
-    docker ps >NUL 2>NUL
+    docker version >NUL 2>NUL
     IF !ERRORLEVEL! NEQ 0 (
-        ECHO [!SCRIPT_NAME!] ERROR: Docker command found, but Docker engine is not responsive or `docker ps` failed. (Error Code: !ERRORLEVEL!)
+        ECHO [!SCRIPT_NAME!] ERROR: Docker command found, but Docker engine is not responsive or `docker version` failed. (Error Code: !ERRORLEVEL!)
         ECHO [!SCRIPT_NAME!] Please ensure Docker Desktop is running correctly and has finished initializing.
         CALL :DockerInstallGuide
         ECHO [!SCRIPT_NAME!] Please re-run this script after ensuring Docker Desktop is fully operational.


### PR DESCRIPTION
Replaced `docker ps` with `docker version` for checking Docker engine responsiveness in the `setup_venv.bat` script.
This is intended to resolve an issue where the script incorrectly detected Docker as unresponsive even when it was running, potentially due to how `docker ps` interacts within the batch script's environment. Updated the associated error message to reflect the command change.