### PR TITLE
Fix: Resolve whisper import conflict in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ pandas
 transformers
 torch
 openai-whisper
-whisper
 sounddevice
 scipy
 pyttsx3


### PR DESCRIPTION
Removes the standalone 'whisper' package from requirements.txt to prevent conflicts with 'openai-whisper'. 'openai-whisper' registers itself as 'whisper' for import, so having both can lead to ImportErrors and incorrect package usage.

This change ensures that 'import whisper' correctly refers to the 'openai-whisper' package, enabling local model usage as intended in voice_input.py and speech_listener.py.