### PR TITLE
Fix: Correct venv activation in batch script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ pandas
 transformers
 torch
 openai-whisper
-whisper
 sounddevice
 scipy
 pyttsx3

--- a/run_ollama_wubu_test.bat
+++ b/run_ollama_wubu_test.bat
@@ -123,7 +123,6 @@ REM ============================================================================
 
 REM ----------------------------------------------------------------------------
 :ActivateVenv
-    SETLOCAL
     ECHO.
     ECHO [!SCRIPT_NAME!] Activating Python virtual environment...
     ECHO [!SCRIPT_NAME!] Venv path: "!VENV_ACTIVATION_SCRIPT!"
@@ -131,7 +130,6 @@ REM ----------------------------------------------------------------------------
     CALL "!VENV_ACTIVATION_SCRIPT!"
     IF "!ERRORLEVEL!" NEQ "0" (EXIT /B 1)
     ECHO [!SCRIPT_NAME!] Virtual environment seems activated.
-    ENDLOCAL
 EXIT /B 0
 
 REM ----------------------------------------------------------------------------


### PR DESCRIPTION
Removes SETLOCAL/ENDLOCAL from the :ActivateVenv subroutine in `run_ollama_wubu_test.bat`.

This ensures that the virtual environment activation persists for the subsequent Python script execution, resolving an issue where the wrong Python interpreter might be used, leading to ImportErrors for packages installed in the venv (e.g., whisper).