### PR TITLE
Fix: Correct LLMProcessor import path in core engine. The import stat…

### DIFF
--- a/src/wubu/core/engine.py
+++ b/src/wubu/core/engine.py
@@ -5,7 +5,7 @@
 import json # Added for tool call argument/result processing
 from ..tts.tts_engine_manager import TTSEngineManager, ZONOS_ENGINE_ID # Import ZONOS_ENGINE_ID for use
 from ..asr.speech_listener import SpeechListener # Import SpeechListener
-from ..llm.llm_processor import LLMProcessor
+from .llm_processor import LLMProcessor # Corrected import
 from ..ui.wubu_ui import WubuApp # Actual class name for type hinting
 
 # Adjust path if desktop_tools is a top-level package or structured differently


### PR DESCRIPTION
…ement for LLMProcessor in `src/wubu/core/engine.py` was using an incorrect relative path (`..llm.llm_processor`), implying `llm_processor` was in a separate `src.wubu.llm` package. This commit changes the import to `from .llm_processor import LLMProcessor`, correctly referencing the module located within the same `src.wubu.core` package. This resolves the `No module named 'src.wubu.llm'` import error that occurred when `engine.py` was loaded.