### PR TITLE
Fix SyntaxError in context_provider.py and improve package structure

### DIFF
--- a/desktop_tools/__init__.py
+++ b/desktop_tools/__init__.py
@@ -1,0 +1,1 @@
+# This file marks 'desktop_tools' as a Python package.

--- a/desktop_tools/context_provider.py
+++ b/desktop_tools/context_provider.py
@@ -313,4 +313,3 @@ if __name__ == '__main__':
         print(f"\nGathering context for query: {context_ignored_query}")
         context_ignored = provider.gather_context(context_ignored_query)
         print(f"Referenced files for ignored query: {context_ignored['referenced_files']}") # Should be empty for data.log
-```

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# This file marks 'src' as a Python package.

--- a/src/wubu/core/engine.py
+++ b/src/wubu/core/engine.py
@@ -427,9 +427,9 @@ if __name__ == '__main__':
     engine.set_ui(mock_ui_instance)
     mock_ui_instance.start() # Start the mock UI
 
-    print("\n--- Test: Process Text Command (WuBu) ---")
-    engine.process_text_command("Hello, WuBu. How are you today?")
-    engine.process_text_command("What is the meaning of life, WuBu?")
+    print("\n--- Test: Process User Prompt (WuBu) ---")
+    engine.process_user_prompt("Hello, WuBu. How are you today?")
+    engine.process_user_prompt("What is the meaning of life, WuBu?")
 
     print("\n--- Test: Shutdown (WuBu) ---")
     engine.shutdown() # This will also stop the mock UI


### PR DESCRIPTION
- Resolved a SyntaxError in desktop_tools/context_provider.py that was likely due to a trailing unterminated block.
- Corrected a call to a renamed method in the test code of src/wubu/core/engine.py.
- Added __init__.py files to the 'src' and 'desktop_tools' directories to explicitly define them as Python packages, enhancing import robustness.