### PR TITLE
Fix: Use ZONOS_LOCAL_ENGINE_ID in core and ui modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,6 +91,15 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 if current_dir not in sys.path:
     sys.path.insert(0, current_dir)
 
+# Cleanse sys.path: Remove <project_root>/src if it's present.
+# This is to prevent issues if PYTHONPATH was set externally to include <project_root>/src,
+# which could lead to incorrect resolution of 'import utils' by third-party libraries
+# as 'src.utils' (looking for a non-existent <project_root>/src/utils.py).
+src_dir_in_path = os.path.join(current_dir, "src")
+if src_dir_in_path in sys.path:
+    print(f"INFO: WuBu is removing potentially problematic path '{src_dir_in_path}' from sys.path.")
+    sys.path.remove(src_dir_in_path)
+
 
 try:
     from src.wubu.core.engine import WuBuEngine

--- a/src/wubu/core/engine.py
+++ b/src/wubu/core/engine.py
@@ -3,7 +3,7 @@
 # TTS, ASR (SpeechListener), LLM processing, and UI interactions.
 
 import json # Added for tool call argument/result processing
-from ..tts.tts_engine_manager import TTSEngineManager, ZONOS_ENGINE_ID # Import ZONOS_ENGINE_ID for use
+from ..tts.tts_engine_manager import TTSEngineManager, ZONOS_LOCAL_ENGINE_ID # Use ZONOS_LOCAL_ENGINE_ID
 from ..asr.speech_listener import SpeechListener # Import SpeechListener
 from .llm_processor import LLMProcessor # Corrected import
 from ..ui.wubu_ui import WubuApp # Actual class name for type hinting

--- a/src/wubu/tts/zonos_local_voice.py
+++ b/src/wubu/tts/zonos_local_voice.py
@@ -12,9 +12,17 @@ from .base_tts_engine import BaseTTSEngine, TTSPlaybackSpeed
 
 # Attempt to import the local Zonos library components
 try:
+    print("[DEBUG_ZLV] Attempting to import Zonos from src.zonos_local_lib.model...")
     from src.zonos_local_lib.model import Zonos
+    print("[DEBUG_ZLV] Successfully imported Zonos.")
+
+    print("[DEBUG_ZLV] Attempting to import make_cond_dict from src.zonos_local_lib.conditioning...")
     from src.zonos_local_lib.conditioning import make_cond_dict #, supported_language_codes (not directly used by engine)
+    print("[DEBUG_ZLV] Successfully imported make_cond_dict.")
+
+    print("[DEBUG_ZLV] Attempting to import DEFAULT_DEVICE from src.zonos_local_lib.utils...")
     from src.zonos_local_lib.utils import DEFAULT_DEVICE as ZONOS_DEFAULT_DEVICE
+    print("[DEBUG_ZLV] Successfully imported DEFAULT_DEVICE.")
 except ImportError as e:
     print(f"ERROR: ZonosLocalVoice - Failed to import local Zonos library: {e}. Ensure zonos_local_lib is correctly placed and importable.")
     # This is a critical error for this engine.

--- a/src/wubu/ui/wubu_ui.py
+++ b/src/wubu/ui/wubu_ui.py
@@ -77,8 +77,8 @@ class WubuApp(ctk.CTk):
             # The engine should have tts_manager
             zonos_engine_instance = None
             if self.engine and self.engine.tts_manager:
-                from ..tts.tts_engine_manager import ZONOS_ENGINE_ID # Safe to import here
-                zonos_engine_instance = self.engine.tts_manager.get_engine(ZONOS_ENGINE_ID)
+                from ..tts.tts_engine_manager import ZONOS_LOCAL_ENGINE_ID # Use ZONOS_LOCAL_ENGINE_ID
+                zonos_engine_instance = self.engine.tts_manager.get_engine(ZONOS_LOCAL_ENGINE_ID)
 
             # Pass the engine instance to the dashboard window if available
             self.zonos_dashboard_window = ZonosDashboardWindow(self, config=self.config, zonos_engine_override=zonos_engine_instance)

--- a/src/zonos_local_lib/conditioning.py
+++ b/src/zonos_local_lib/conditioning.py
@@ -57,51 +57,28 @@ import sys
 import re
 import unicodedata
 
+print("[DEBUG_IMPORT] Attempting to import inflect...")
 import inflect
+print("[DEBUG_IMPORT] Successfully imported inflect.")
+
 # import torch # already imported
 # import torch.nn as nn # already imported
+
+print("[DEBUG_IMPORT] Attempting to import number2kanji from kanjize...")
 from kanjize import number2kanji
+print("[DEBUG_IMPORT] Successfully imported number2kanji from kanjize.")
+
+print("[DEBUG_IMPORT] Attempting to import EspeakBackend from phonemizer.backend...")
 from phonemizer.backend import EspeakBackend
+print("[DEBUG_IMPORT] Successfully imported EspeakBackend from phonemizer.backend.")
+
+print("[DEBUG_IMPORT] Attempting to import Dictionary, SplitMode from sudachipy...")
 from sudachipy import Dictionary, SplitMode
+print("[DEBUG_IMPORT] Successfully imported Dictionary, SplitMode from sudachipy.")
 
-# This will be handled in Step 3 of the plan more robustly.
-# For now, keeping original logic during file creation.
-
-# Set PHONEMIZER_ESPEAK_LIBRARY for different platforms if not already set by environment
-# This code runs when the module is imported.
-if "PHONEMIZER_ESPEAK_LIBRARY" not in os.environ:
-    if sys.platform == "win32":
-        # Standard installation path for eSpeak NG MSI on Windows
-        espeak_ng_dll_path = "C:\\Program Files\\eSpeak NG\\libespeak-ng.dll"
-        if os.path.exists(espeak_ng_dll_path):
-            os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = espeak_ng_dll_path
-            print(f"INFO: Zonos.conditioning - Set PHONEMIZER_ESPEAK_LIBRARY to {espeak_ng_dll_path}", file=sys.stderr)
-        else:
-            # Fallback for older eSpeak or different Program Files location
-            espeak_ng_dll_path_x86 = "C:\\Program Files (x86)\\eSpeak NG\\libespeak-ng.dll"
-            if os.path.exists(espeak_ng_dll_path_x86):
-                os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = espeak_ng_dll_path_x86
-                print(f"INFO: Zonos.conditioning - Set PHONEMIZER_ESPEAK_LIBRARY to {espeak_ng_dll_path_x86}", file=sys.stderr)
-            else:
-                print("WARNING: Zonos.conditioning - PHONEMIZER_ESPEAK_LIBRARY not set and default eSpeak NG DLL paths not found. Phonemizer might fail.", file=sys.stderr)
-    elif sys.platform == "darwin": # macOS
-        # Common path for eSpeak NG installed via Homebrew on Apple Silicon / Intel
-        homebrew_path = None
-        if os.path.exists("/opt/homebrew/lib/libespeak-ng.dylib"): # Apple Silicon
-            homebrew_path = "/opt/homebrew/lib/libespeak-ng.dylib"
-        elif os.path.exists("/usr/local/lib/libespeak-ng.dylib"): # Intel Macs
-            homebrew_path = "/usr/local/lib/libespeak-ng.dylib"
-
-        if homebrew_path:
-            os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = homebrew_path
-            print(f"INFO: Zonos.conditioning - Set PHONEMIZER_ESPEAK_LIBRARY to {homebrew_path}", file=sys.stderr)
-        else:
-            print("WARNING: Zonos.conditioning - PHONEMIZER_ESPEAK_LIBRARY not set for macOS and default Homebrew paths not found. Phonemizer might fail.", file=sys.stderr)
-    # For Linux, phonemizer usually finds it automatically if espeak-ng is installed system-wide.
-    # No explicit setting here unless a specific non-standard path is common.
-else:
-    print(f"INFO: Zonos.conditioning - PHONEMIZER_ESPEAK_LIBRARY is already set to '{os.environ['PHONEMIZER_ESPEAK_LIBRARY']}'. Using that.", file=sys.stderr)
-
+# PHONEMIZER_ESPEAK_LIBRARY configuration is now handled centrally in main.py
+# to ensure it's set before any module (like phonemizer) that might need it is imported.
+# The main.py script calls _configure_espeak_for_phonemizer() at its start.
 
 # --- Number normalization code from https://github.com/daniilrobnikov/vits2/blob/main/text/normalize_numbers.py ---
 

--- a/src/zonos_local_lib/speaker_cloning.py
+++ b/src/zonos_local_lib/speaker_cloning.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 import torchaudio
 from huggingface_hub import hf_hub_download
 
-from ..utils import DEFAULT_DEVICE # Adjusted import
+from .utils import DEFAULT_DEVICE # Corrected relative import
 
 
 class logFbankCal(nn.Module):


### PR DESCRIPTION
Updated src/wubu/core/engine.py and src/wubu/ui/wubu_ui.py to import and use ZONOS_LOCAL_ENGINE_ID from tts_engine_manager.py instead of the previously used ZONOS_ENGINE_ID, which is no longer defined.

This resolves the ImportError: cannot import name 'ZONOS_ENGINE_ID'.