### PR TITLE
Fix CFG conditioning batch size in ZonosLocalVoice

### DIFF
--- a/src/wubu/tts/zonos_local_voice.py
+++ b/src/wubu/tts/zonos_local_voice.py
@@ -194,8 +194,33 @@ class ZonosLocalVoice(BaseTTSEngine):
         }
 
         try:
-            cond_dict = make_cond_dict(**cond_params)
-            conditioning = self.zonos_model.prepare_conditioning(cond_dict) # CFG handled inside if uncond_dict is passed by make_cond_dict logic
+            # Create conditional dictionary
+            # Assuming make_cond_dict itself doesn't return two dicts, we prepare them for Zonos.prepare_conditioning
+            main_cond_dict = make_cond_dict(**cond_params)
+
+            uncond_dict_for_prepare = None
+            if cfg_active:
+                # Create parameters for the unconditional dictionary
+                uncond_params = cond_params.copy()
+                # Nullify specified keys for the unconditional pass
+                # Note: make_cond_dict might also use its 'unconditional_keys' argument to do this internally
+                # if it's designed to produce an uncond_dict. If it only produces one dict based on input,
+                # then we must modify its inputs.
+
+                # Example of nullifying:
+                if "speaker" in unconditional_keys_cfg: # unconditional_keys_cfg is a set
+                    uncond_params['speaker'] = None
+                if "emotion" in unconditional_keys_cfg:
+                     # Using a generic or average emotion; Zonos's make_cond_dict might have specific defaults
+                    uncond_params['emotion'] = [0.125] * 8 # Example neutral emotion for 8 emotion categories
+                # If "text" were in unconditional_keys_cfg, one might set:
+                # uncond_params['text'] = "" # Or specific null text handling for Zonos
+
+                # Re-call make_cond_dict with modified params for unconditional part
+                uncond_dict_for_prepare = make_cond_dict(**uncond_params)
+
+            # Pass both dictionaries to prepare_conditioning
+            conditioning = self.zonos_model.prepare_conditioning(main_cond_dict, uncond_dict_for_prepare)
 
             # TODO: Handle audio_prefix_codes similar to Gradio if needed
             # audio_prefix_codes = None

--- a/src/wubu/ui/wubu_ui.py
+++ b/src/wubu/ui/wubu_ui.py
@@ -426,7 +426,7 @@ class ZonosDashboardWindow(ctk.CTkToplevel):
             self.master_app.display_message_popup("Input Error", "Please enter some text to synthesize.", "error")
             return
 
-        if not self.current_speaker_embedding:
+        if self.current_speaker_embedding is None:
             # Option: try to use default_voice from ZonosEngine if set, or prompt to generate.
             # For now, require explicit embedding generation in this UI.
             self.synthesis_status_label.configure(text="Status: No speaker embedding. Please generate one first.")


### PR DESCRIPTION
When CFG is active and no audio prefix codes are provided, the Zonos model expects the `prefix_conditioning` tensor to have an even batch size (representing concatenated conditional and unconditional parts).

The `synthesize_to_bytes` method in `ZonosLocalVoice` was previously only preparing a single conditional part, leading to an odd batch size (e.g., 1) for `prefix_conditioning`.

This commit modifies `synthesize_to_bytes` to:
1. Detect if CFG is active based on `cfg_scale`.
2. If active, create parameters for an unconditional pass by nullifying keys specified in `unconditional_keys_cfg` (e.g., speaker, emotion).
3. Call `make_cond_dict` for both conditional and unconditional parameters.
4. Pass both resulting dictionaries to `Zonos.prepare_conditioning`.

This ensures `prefix_conditioning` has the correct doubled batch size for CFG, resolving the `ValueError` in `Zonos.generate`.