### PR TITLE
Fix device placement for RoPE freqs_cis in TorchZonosBackbone

### DIFF
--- a/src/wubu/ui/wubu_ui.py
+++ b/src/wubu/ui/wubu_ui.py
@@ -426,7 +426,7 @@ class ZonosDashboardWindow(ctk.CTkToplevel):
             self.master_app.display_message_popup("Input Error", "Please enter some text to synthesize.", "error")
             return
 
-        if not self.current_speaker_embedding:
+        if self.current_speaker_embedding is None:
             # Option: try to use default_voice from ZonosEngine if set, or prompt to generate.
             # For now, require explicit embedding generation in this UI.
             self.synthesis_status_label.configure(text="Status: No speaker embedding. Please generate one first.")

--- a/src/zonos_local_lib/backbone/_torch.py
+++ b/src/zonos_local_lib/backbone/_torch.py
@@ -62,19 +62,51 @@ class TorchZonosBackbone(nn.Module):
         self.norm_f = nn.LayerNorm(config.d_model, eps=config.norm_epsilon)
 
     def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
-        # TODO: This function should be pure
         head_dim = self.config.d_model // self.config.attn_cfg["num_heads"]
-        self.freqs_cis = precompute_freqs_cis(16384, head_dim)
+
+        # Determine the target device from an existing parameter of the module
+        module_device = self.norm_f.weight.device
+
+        # Compute freqs_cis on CPU then move to target device if not already there or on correct device
+        # Check if it needs recomputation or moving (e.g. if device changed or not initialized)
+        if not hasattr(self, 'freqs_cis') or self.freqs_cis.device != module_device or self.freqs_cis.shape[0] < 16384 : # check size too
+            # Max sequence length for RoPE is often fixed (e.g., 16384 or a large value from config)
+            cpu_freqs_cis = precompute_freqs_cis(16384, head_dim) # This is on CPU
+            self.freqs_cis = cpu_freqs_cis.to(module_device)
+
         return {
-            i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype)
+            i: layer.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype, device=module_device) # Pass device
             for i, layer in enumerate(self.layers)
         }
 
     def forward(self, hidden_states: torch.Tensor, inference_params: InferenceParams) -> torch.Tensor:
-        input_pos = torch.arange(0, hidden_states.shape[1], device=hidden_states.device)
-        input_pos = input_pos + inference_params.lengths_per_sample.unsqueeze(-1)
+        current_device = hidden_states.device
+        input_pos = torch.arange(0, hidden_states.shape[1], device=current_device)
 
-        freqs_cis = self.freqs_cis[input_pos].expand(hidden_states.shape[0], -1, -1, -1)
+        # Ensure lengths_per_sample is on the same device as input_pos for the addition
+        lengths_per_sample_on_device = inference_params.lengths_per_sample.to(current_device)
+        input_pos = input_pos + lengths_per_sample_on_device.unsqueeze(-1)
+
+        # self.freqs_cis should now be on current_device due to changes in allocate_inference_cache
+        # However, input_pos might still be on a different device if hidden_states.device was different
+        # from self.freqs_cis.device at the time of freqs_cis creation.
+        # Safest is to ensure input_pos is on the same device as self.freqs_cis OR input_pos is CPU.
+        # Since self.freqs_cis is now moved to module_device, input_pos should also be on module_device.
+        # hidden_states.device (current_device) should be module_device.
+
+        # If self.freqs_cis is guaranteed to be on current_device:
+        freqs_cis_for_indexing = self.freqs_cis
+        indices_for_indexing = input_pos
+
+        # If there's a chance self.freqs_cis is on CPU and input_pos on CUDA (or vice-versa in error):
+        if freqs_cis_for_indexing.device != indices_for_indexing.device:
+            # This case should ideally not happen if allocate_inference_cache sets freqs_cis to current_device
+            # and current_device is consistent. But as a safeguard:
+            indices_for_indexing = indices_for_indexing.to(freqs_cis_for_indexing.device)
+
+        selected_freqs_cis = freqs_cis_for_indexing[indices_for_indexing]
+        freqs_cis = selected_freqs_cis.expand(hidden_states.shape[0], -1, -1, -1)
+
         for i, layer in enumerate(self.layers):
             hidden_states = layer(hidden_states, inference_params, freqs_cis)
         return self.norm_f(hidden_states)
@@ -93,8 +125,8 @@ class TransformerBlock(nn.Module):
         self.num_heads_kv = config.attn_cfg["num_heads_kv"]
         self.head_dim = config.d_model // config.attn_cfg["num_heads"]
 
-    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16):
-        return torch.empty(batch_size, max_seqlen, 2, self.num_heads_kv, self.head_dim, dtype=dtype), None
+    def allocate_inference_cache(self, batch_size: int, max_seqlen: int, dtype: torch.dtype = torch.bfloat16, device: torch.device = None):
+        return torch.empty(batch_size, max_seqlen, 2, self.num_heads_kv, self.head_dim, dtype=dtype, device=device), None
 
     def forward(self, x: torch.Tensor, inference_params: InferenceParams, freqs_cis: torch.Tensor) -> torch.Tensor:
         x = x + self.mixer(self.norm(x), inference_params, freqs_cis)

--- a/src/zonos_local_lib/model.py
+++ b/src/zonos_local_lib/model.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 from .autoencoder import DACAutoencoder
 from .backbone import BACKBONES
+# from .backbone._torch import TorchZonosBackbone # Optional: if TorchZonosBackbone is also checked by name
 from .codebook_pattern import apply_delay_pattern, revert_delay_pattern
 from .conditioning import PrefixConditioner # Assuming make_cond_dict is also in conditioning or handled by Gradio
 from .config import InferenceParams, ZonosConfig
@@ -256,7 +257,8 @@ class Zonos(nn.Module):
         classifier-free guidance if `cfg_scale != 1.0`.
         """
         # Backbone might take inference_params or not depending on type
-        if isinstance(self.backbone, MambaSSMZonosBackbone): # Mamba uses it
+        # Check class name string to avoid direct import of MambaSSMZonosBackbone
+        if self.backbone.__class__.__name__ == "MambaSSMZonosBackbone": # Mamba uses it
             last_hidden_states_out = self.backbone(hidden_states, inference_params)
         else: # Torch transformer backbone in example doesn't use inference_params in its forward directly in this way for single step
               # but the kv_cache is updated via inference_params.


### PR DESCRIPTION
Resolves a RuntimeError in `TorchZonosBackbone.forward` caused by a device mismatch when indexing `self.freqs_cis` with `input_pos`.

Changes:
1. In `TorchZonosBackbone.allocate_inference_cache`:
   - `self.freqs_cis` is now explicitly moved to the module's detected device after being computed (which defaults to CPU).
   - The determined `module_device` is passed to the `allocate_inference_cache` method of sub-layers (`TransformerBlock`).
2. In `TorchZonosBackbone.forward`:
   - Ensured `inference_params.lengths_per_sample` is on the same device as `input_pos` before their addition.
   - Added a safeguard (though ideally not hit now) to move `input_pos` to `self.freqs_cis.device` if they somehow still differ before indexing.
3. In `TransformerBlock.allocate_inference_cache`:
   - Modified to accept a `device` argument and use it when creating the KV cache tensor with `torch.empty`.

These changes ensure that `self.freqs_cis` and the indices used to access it are on the same device, preventing the runtime error.