### PR TITLE
Fix: Use AutoModel for DAC and refine preprocessing

### DIFF
--- a/src/zonos_local_lib/autoencoder.py
+++ b/src/zonos_local_lib/autoencoder.py
@@ -2,26 +2,85 @@ import math
 
 import torch
 import torchaudio
-from transformers.models.dac import DacModel
+# from transformers.models.dac import DacModel # Remove this direct import
+from transformers import AutoModel # Use AutoModel
 
 
 class DACAutoencoder:
     def __init__(self):
         super().__init__()
-        self.dac = DacModel.from_pretrained("descript/dac_44khz")
+        # Load using AutoModel, let transformers figure out the correct class
+        self.dac = AutoModel.from_pretrained("descript/dac_44khz")
+        # It's good practice to check if the loaded model is what we expect,
+        # though for well-known models, AutoModel is usually reliable.
+        # You might need to ensure methods like .encode, .decode, .quantizer.n_codebooks,
+        # .config.codebook_size, .config.sampling_rate are available on the object returned by AutoModel.
+        # For "descript/dac_44khz", AutoModel should indeed return a DacModel instance or compatible.
+
         self.dac.eval().requires_grad_(False)
+
+        # These attributes might need to be accessed differently if AutoModel wraps DacModel unexpectedly
+        # or if the config structure changes slightly with AutoModel.
+        # For now, assume they are available as before.
+        if hasattr(self.dac, 'quantizer') and hasattr(self.dac.quantizer, 'n_codebooks'):
+             self.num_codebooks = self.dac.quantizer.n_codebooks
+        elif hasattr(self.dac, 'config') and hasattr(self.dac.config, 'num_codebooks'): # Fallback if structure differs
+             self.num_codebooks = self.dac.config.num_codebooks
+        elif hasattr(self.dac, 'config') and hasattr(self.dac.config, 'n_codebooks'): # Zonos reference uses this
+            self.num_codebooks = self.dac.config.n_codebooks
+        else:
+            # Fallback or error if n_codebooks cannot be found.
+            # This might indicate an incompatible model or version.
+            # For "descript/dac_44khz", it should typically be found.
+            print("WARNING: Could not determine num_codebooks from DAC model config. Attempting direct access or default.")
+            # Try direct access as per original transformers DacModel structure if possible
+            if hasattr(self.dac, 'quantizer') and hasattr(self.dac.quantizer, 'n_codebooks'):
+                 self.num_codebooks = self.dac.quantizer.n_codebooks
+            else:
+                 # Defaulting to a common value if not found, though this is risky.
+                 self.num_codebooks = getattr(self.dac.config, "n_codebooks", 9)
+                 print(f"WARNING: num_codebooks defaulted to {self.num_codebooks}. This might be incorrect.")
+
+
         self.codebook_size = self.dac.config.codebook_size
-        self.num_codebooks = self.dac.quantizer.n_codebooks
         self.sampling_rate = self.dac.config.sampling_rate
 
     def preprocess(self, wav: torch.Tensor, sr: int) -> torch.Tensor:
-        wav = torchaudio.functional.resample(wav, sr, 44_100)
-        right_pad = math.ceil(wav.shape[-1] / 512) * 512 - wav.shape[-1]
-        return torch.nn.functional.pad(wav, (0, right_pad))
+        # Resample to the DAC model's native sampling rate
+        if sr != self.sampling_rate:
+            wav = torchaudio.functional.resample(wav, sr, self.sampling_rate)
+
+        # Pad to be a multiple of model's hop length (often 512 for DAC/EnCodec style models)
+        # This might depend on the specific model's requirements, often related to its downsampling factor.
+        # A common hop length or total downsampling factor for such models is 2^N, e.g., 256, 320, 512.
+        # The original code used 512. Let's assume this is a stride/hop factor.
+        # If the model has a specific stride, use that. Otherwise, 512 is a common value.
+        # For descript/dac_44khz, the total stride is 320.
+        model_stride = getattr(self.dac.config, "hop_length", None) # Check if hop_length is in config
+        if model_stride is None and hasattr(self.dac.config, "upsample_rates"): # For DAC, stride is product of upsample_rates
+            model_stride = 1
+            for r in self.dac.config.upsample_rates:
+                model_stride *= r
+
+        if model_stride is None: # Fallback if not found
+            print("Warning: Could not determine model_stride for DACAutoencoder padding. Using default 512.")
+            model_stride = 512
+
+        if wav.shape[-1] % model_stride != 0:
+            right_pad = model_stride - (wav.shape[-1] % model_stride)
+            wav = torch.nn.functional.pad(wav, (0, right_pad))
+
+        return wav
 
     def encode(self, wav: torch.Tensor) -> torch.Tensor:
+        # The .encode() method should exist on the model returned by AutoModel for DAC
         return self.dac.encode(wav).audio_codes
 
     def decode(self, codes: torch.Tensor) -> torch.Tensor:
-        with torch.autocast(self.dac.device.type, torch.float16, enabled=self.dac.device.type != "cpu"):
+        # The .decode() method should exist
+        # Ensure device handling for autocast is correct; self.dac.device might be needed
+        device_type = self.dac.device.type if hasattr(self.dac, 'device') else "cpu"
+        # Ensure codes are on the same device as the model for decode
+        codes = codes.to(self.dac.device)
+        with torch.autocast(device_type, dtype=torch.float16, enabled=(device_type != "cpu")):
             return self.dac.decode(audio_codes=codes).audio_values.unsqueeze(1).float()

--- a/src/zonos_local_lib/conditioning.py
+++ b/src/zonos_local_lib/conditioning.py
@@ -4,8 +4,8 @@ from typing import Any, Literal, Iterable
 import torch
 import torch.nn as nn
 
-from .config import PrefixConditionerConfig # Corrected import
-from .utils import DEFAULT_DEVICE # Corrected import
+from .config import PrefixConditionerConfig
+from .utils import DEFAULT_DEVICE
 
 
 class Conditioner(nn.Module):
@@ -47,6 +47,22 @@ class Conditioner(nn.Module):
             return self.uncond_vector.data.view(1, 1, -1)
 
         cond = self.apply_cond(*inputs)
+
+        # Ensure 'cond' tensor has the same dtype as the projection layer's weights
+        # if the projection layer is a Linear layer or an MLP (Sequential containing Linear).
+        if isinstance(self.project, nn.Linear):
+            if hasattr(self.project, 'weight') and cond.dtype != self.project.weight.dtype:
+                cond = cond.to(self.project.weight.dtype)
+        elif isinstance(self.project, nn.Sequential):
+            # Find the first linear layer in the sequential to get the target dtype
+            target_dtype = None
+            for layer in self.project:
+                if isinstance(layer, nn.Linear) and hasattr(layer, 'weight'):
+                    target_dtype = layer.weight.dtype
+                    break
+            if target_dtype and cond.dtype != target_dtype:
+                cond = cond.to(target_dtype)
+
         cond = self.project(cond)
         return cond
 
@@ -57,28 +73,15 @@ import sys
 import re
 import unicodedata
 
-print("[DEBUG_IMPORT] Attempting to import inflect...")
 import inflect
-print("[DEBUG_IMPORT] Successfully imported inflect.")
-
-# import torch # already imported
-# import torch.nn as nn # already imported
-
-print("[DEBUG_IMPORT] Attempting to import number2kanji from kanjize...")
+import torch
+import torch.nn as nn
 from kanjize import number2kanji
-print("[DEBUG_IMPORT] Successfully imported number2kanji from kanjize.")
-
-print("[DEBUG_IMPORT] Attempting to import EspeakBackend from phonemizer.backend...")
 from phonemizer.backend import EspeakBackend
-print("[DEBUG_IMPORT] Successfully imported EspeakBackend from phonemizer.backend.")
-
-print("[DEBUG_IMPORT] Attempting to import Dictionary, SplitMode from sudachipy...")
 from sudachipy import Dictionary, SplitMode
-print("[DEBUG_IMPORT] Successfully imported Dictionary, SplitMode from sudachipy.")
 
-# PHONEMIZER_ESPEAK_LIBRARY configuration is now handled centrally in main.py
-# to ensure it's set before any module (like phonemizer) that might need it is imported.
-# The main.py script calls _configure_espeak_for_phonemizer() at its start.
+if sys.platform == "darwin":
+    os.environ["PHONEMIZER_ESPEAK_LIBRARY"] = "/opt/homebrew/lib/libespeak-ng.dylib"
 
 # --- Number normalization code from https://github.com/daniilrobnikov/vits2/blob/main/text/normalize_numbers.py ---
 
@@ -173,10 +176,10 @@ def get_symbol_ids(text: str) -> list[int]:
     return list(map(_get_symbol_id, text))
 
 
-def tokenize_phonemes(phonemes_list: list[str]) -> tuple[torch.Tensor, list[int]]: # Renamed phonemes to phonemes_list to avoid conflict
-    phoneme_ids = [[BOS_ID, *get_symbol_ids(p), EOS_ID] for p in phonemes_list] # Used p here
+def tokenize_phonemes(phonemes: list[str]) -> tuple[torch.Tensor, list[int]]:
+    phoneme_ids = [[BOS_ID, *get_symbol_ids(phonemes), EOS_ID] for phonemes in phonemes]
     lengths = list(map(len, phoneme_ids))
-    longest = max(lengths) if lengths else 0
+    longest = max(lengths)
     phoneme_ids = [[PAD_ID] * (longest - len(ids)) + ids for ids in phoneme_ids]
     return torch.tensor(phoneme_ids), lengths
 
@@ -203,7 +206,8 @@ def clean(texts: list[str], languages: list[str]) -> list[str]:
 def get_backend(language: str) -> "EspeakBackend":
     import logging
 
-    # from phonemizer.backend import EspeakBackend # already imported
+    from phonemizer.backend import EspeakBackend
+
     logger = logging.getLogger("phonemizer")
     backend = EspeakBackend(
         language,
@@ -222,8 +226,8 @@ def phonemize(texts: list[str], languages: list[str]) -> list[str]:
     batch_phonemes = []
     for text, language in zip(texts, languages):
         backend = get_backend(language)
-        phonemes_output = backend.phonemize([text], strip=True) # Renamed phonemes to phonemes_output
-        batch_phonemes.append(phonemes_output[0])
+        phonemes = backend.phonemize([text], strip=True)
+        batch_phonemes.append(phonemes[0])
 
     return batch_phonemes
 
@@ -241,8 +245,8 @@ class EspeakPhonemeConditioner(Conditioner):
         """
         device = self.phoneme_embedder.weight.device
 
-        phonemes_data = phonemize(texts, languages) # Renamed phonemes to phonemes_data
-        phoneme_ids, _ = tokenize_phonemes(phonemes_data) # Used phonemes_data
+        phonemes = phonemize(texts, languages)
+        phoneme_ids, _ = tokenize_phonemes(phonemes)
         phoneme_embeds = self.phoneme_embedder(phoneme_ids.to(device))
 
         return phoneme_embeds
@@ -319,41 +323,10 @@ class PrefixConditioner(Conditioner):
         conds = []
         for conditioner in self.conditioners:
             conds.append(conditioner(cond_dict.get(conditioner.name)))
-        max_bsz = max(map(len, conds)) if conds else 1 # Handle empty conds
-        # Ensure conds is not empty before proceeding with assertions or expansions
-        if conds:
-            assert all(c.shape[0] in (max_bsz, 1) for c in conds)
-            conds = [c.expand(max_bsz, -1, -1) for c in conds]
-            return self.norm(self.project(torch.cat(conds, dim=-2)))
-        else: # Handle case where there are no conditioners or all are unconditional
-            # This might need specific handling based on expected behavior if all conditioners are optional
-            # For now, return a zero tensor or handle as per specific logic if this case is valid.
-            # Assuming project can handle an empty sum or this path isn't typically hit with an empty list.
-            # If an error should be raised or a default tensor returned, that logic would go here.
-            # For now, to prevent error with torch.cat on empty list:
-            if self.uncond_vector is not None: # If the PrefixConditioner itself can be uncond
-                 return self.uncond_vector.data.view(1, 1, -1).expand(max_bsz, -1, -1) # Should be 1, not max_bsz if no other conds
-            # Fallback or error if no conditions and no uncond_vector for PrefixConditioner
-            # This state might indicate a configuration error.
-            # Let's assume for now an empty list of conditions means an empty tensor or error.
-            # For safety, let's return an empty tensor of the correct dimension, if that's a valid interpretation.
-            # This part is speculative without knowing the exact design intent for zero conditioners.
-            # Defaulting to a behavior that avoids crashing; requires design confirmation.
-            # One possible interpretation: If no actual conditions are processed, maybe it means no prefix.
-            # However, self.project likely expects some input.
-            # A simple fix to avoid torch.cat error if conds is empty:
-            if not conds and self.uncond_vector is None: # No specific conditions to concat and no uncond prefix
-                 # This case needs clarification. For now, let's assume it should pass a zero tensor if project expects input.
-                 # Or, if self.project is Identity, an empty tensor might be problematic later.
-                 # A more robust approach might involve how `uncond_type` for PrefixConditioner itself is handled.
-                 # If this path is reached, it means all sub-conditioners were optional and none were provided.
-                 # Returning a zero tensor of output_dim. Batch size and sequence length are tricky here.
-                 # Let's assume batch_size 1, seq_len 1 for such a case.
-                 return torch.zeros(1, 1, self.output_dim, device=DEFAULT_DEVICE) # Speculative
-            # If conds was not empty, the original return self.norm(self.project(torch.cat(conds, dim=-2))) is fine.
-            # The issue is only if conds is empty.
-            # The above return is for the case conds is empty AND self.uncond_vector is None.
-            # If self.uncond_vector is not None, it's handled by the initial check in Conditioner.forward
+        max_bsz = max(map(len, conds))
+        assert all(c.shape[0] in (max_bsz, 1) for c in conds)
+        conds = [c.expand(max_bsz, -1, -1) for c in conds]
+        return self.norm(self.project(torch.cat(conds, dim=-2)))
 
 
 supported_language_codes = [
@@ -393,12 +366,7 @@ def make_cond_dict(
     pitch_std: float = 20.0,
 
     # Speaking rate in phonemes per minute (0 to 40). 30 is very fast, 10 is slow.
-    # This seems to be a misinterpretation in the original comment.
-    # Zonos model.py generate() has `max_new_tokens: int = 86 * 30`. 86 Hz is ~5160 tokens/min.
-    # The `rate` argument in zonos_docker_entry.py is a multiplier (e.g. 1.0 for normal).
-    # Let's assume this 'speaking_rate' is intended to be a multiplier like the 'rate' arg.
-    # Typical range for rate multiplier: 0.5 (slow) to 2.0 (fast). Defaulting to 1.0.
-    speaking_rate: float = 1.0, # Adjusted interpretation and default
+    speaking_rate: float = 15.0,
 
     # Target VoiceQualityScore for the generated speech (0.5 to 0.8).
     #   A list of values must be provided which represent each 1/8th of the audio.
@@ -413,88 +381,41 @@ def make_cond_dict(
     dnsmos_ovrl: float = 4.0,
     # Only used for the hybrid model
     speaker_noised: bool = False,
-    unconditional_keys: Iterable[str] = {"vqscore_8", "dnsmos_ovrl"}, # Default from Gradio
+    unconditional_keys: Iterable[str] = {"vqscore_8", "dnsmos_ovrl"},
     device: torch.device | str = DEFAULT_DEVICE,
 ) -> dict:
     """
     A helper to build the 'cond_dict' that the model expects.
     By default, it will generate a random speaker embedding
     """
-    # Ensure language is valid, default to en-us if not.
-    # The original code asserted, but it might be better to default or warn.
-    if language.lower() not in supported_language_codes:
-        print(f"WARNING: Language code '{language}' not in supported list. Defaulting to 'en-us'.", file=sys.stderr)
-        language = "en-us"
-
+    assert language.lower() in supported_language_codes, "Please pick a supported language"
 
     language_code_to_id = {lang: i for i, lang in enumerate(supported_language_codes)}
 
-    cond_dict_prep = { # Renamed to avoid modifying the input `cond_dict` if it were passed
-        "espeak": ([text], [language]), # espeak conditioner expects a list of texts and list of languages
-        "speaker": speaker, # speaker embedding tensor
-        "emotion": emotion, # list of floats for emotion vector
-        "fmax": fmax, # float
-        "pitch_std": pitch_std, # float
-        "speaking_rate": speaking_rate, # float (rate multiplier)
-        "language_id": language_code_to_id[language.lower()], # integer id
-        "vqscore_8": vqscore_8, # list of floats
-        "ctc_loss": ctc_loss, # float
-        "dnsmos_ovrl": dnsmos_ovrl, # float
-        "speaker_noised": int(speaker_noised), # integer (0 or 1)
+    cond_dict = {
+        "espeak": ([text], [language]),
+        "speaker": speaker,
+        "emotion": emotion,
+        "fmax": fmax,
+        "pitch_std": pitch_std,
+        "speaking_rate": speaking_rate,
+        "language_id": language_code_to_id[language],
+        "vqscore_8": vqscore_8,
+        "ctc_loss": ctc_loss,
+        "dnsmos_ovrl": dnsmos_ovrl,
+        "speaker_noised": int(speaker_noised),
     }
 
-    # Remove keys that are meant to be unconditional
-    final_cond_dict = {}
-    for k, v in cond_dict_prep.items():
-        if k not in unconditional_keys:
-            final_cond_dict[k] = v
-        # else: # Optionally print which keys are being made unconditional
-            # print(f"INFO: Key '{k}' is being made unconditional.", file=sys.stderr)
+    for k in unconditional_keys:
+        cond_dict.pop(k, None)
 
-
-    # Convert numericals and lists to tensors on the specified device
-    for k, v in final_cond_dict.items():
-        if k == "espeak": # Special handling for espeak as it's (list[str], list[str])
-            # This is passed as is to EspeakPhonemeConditioner
-            continue
+    for k, v in cond_dict.items():
         if isinstance(v, (float, int, list)):
-            try:
-                v_tensor = torch.tensor(v, device=device)
-            except TypeError as e: # Handles cases like list of mixed types if any, or non-numeric lists
-                print(f"WARNING: Could not convert value for key '{k}' to tensor: {v}. Error: {e}", file=sys.stderr)
-                # Decide on fallback: skip this key, or use a default tensor, or re-raise
-                continue # Skip this problematic key for now
-        elif isinstance(v, torch.Tensor):
-            v_tensor = v.to(device)
-        else: # value is None (e.g. speaker not provided) or already in a non-convertible format
-            final_cond_dict[k] = v # Keep as is (e.g. None)
-            continue
+            v = torch.tensor(v)
+        if isinstance(v, torch.Tensor):
+            cond_dict[k] = v.view(1, 1, -1).to(device)
 
-        # Reshape to [batch_size, seq_len, features] where batch_size and seq_len are 1 for scalar-like conditioners
-        if v_tensor.ndim == 0: # scalar
-            v_tensor = v_tensor.view(1, 1, 1)
-        elif v_tensor.ndim == 1: # list like [0.1, 0.2, 0.3]
-            v_tensor = v_tensor.view(1, 1, -1)
-        # If ndim is 2 or more, assume it's already correctly shaped [batch, seq, feat] or [batch, feat]
-        # or specific shapes like speaker embedding.
-        # The example shows view(1,1,-1) for all, which might be too aggressive for pre-shaped tensors.
-        # Let's stick to the original logic for this part mostly.
-        # The original code did: v.view(1, 1, -1).to(device) for all tensors.
+        if k == "emotion":
+            cond_dict[k] /= cond_dict[k].sum(dim=-1)
 
-        final_cond_dict[k] = v_tensor.view(1, 1, -1) # Ensure [1,1,N] shape as per original
-
-        if k == "emotion" and final_cond_dict[k] is not None: # Normalize emotion tensor if present
-            current_emotion_tensor = final_cond_dict[k]
-            sum_emotion = current_emotion_tensor.sum(dim=-1, keepdim=True)
-            # Avoid division by zero if sum is zero (e.g. all zeros provided)
-            if sum_emotion.abs().item() > 1e-6 : # Check if sum is significantly non-zero
-                 final_cond_dict[k] = current_emotion_tensor / sum_emotion
-            else:
-                # Handle all-zero emotion vector, e.g. set to uniform or warn
-                print("WARNING: Emotion vector sums to zero, cannot normalize. Using as is or consider a default.", file=sys.stderr)
-                # Optionally, set to a default uniform distribution if sum is zero
-                # num_emotions = current_emotion_tensor.shape[-1]
-                # final_cond_dict[k] = torch.full_like(current_emotion_tensor, 1.0/num_emotions)
-
-
-    return final_cond_dict
+    return cond_dict

--- a/src/zonos_local_lib/sampling.py
+++ b/src/zonos_local_lib/sampling.py
@@ -18,60 +18,9 @@ def multinomial(input: torch.Tensor, num_samples: int, replacement=False, *, gen
 
     if num_samples == 1:
         q = torch.empty_like(input).exponential_(1, generator=generator)
-        # Add a small epsilon to input to prevent division by zero if input contains zeros,
-        # though for probabilities, this should ideally not happen if properly normalized.
-        # However, q can be zero if exponential_(1) produces a very large number, making 1/q zero.
-        # A safer way is to use log-space sampling or ensure input probabilities are > 0.
-        # For now, let's assume input is well-behaved (all non-negative, sums to 1).
-        # If input can be zero, input/q can be NaN or Inf.
-        # Gumbel-max trick: argmax(log(probs) + G) where G ~ Gumbel(0,1)
-        # Or simpler: argmax(probs / random_exponential)
-        # If input has zeros, those will remain zero. If q is zero for a non-zero input, it's Inf.
-        # Let's ensure q is not zero where input is not zero.
-        # q = torch.where(input > 0, q.clamp_min(1e-20), torch.inf) # Avoid division by zero only for valid inputs
-
-        # A simpler approach if `input` contains probabilities (non-negative, sums to 1):
-        # if torch.any(input < 0) or not torch.allclose(input.sum(dim=-1), torch.tensor(1.0, device=input.device, dtype=input.dtype)):
-            # print("Warning: Input to multinomial may not be normalized probabilities.")
-            # input = torch.softmax(input, dim=-1) # Force normalization if concerned
-
-        # Original gumbel-like sampling:
-        # For stability with potential zeros in `input` from softmax (e.g. from -inf logits)
-        # or if `q` from exponential_ can be problematic.
-        # Alternative: Gumbel-Max trick uses `logits + gumbel_noise`.
-        # Here we have `probs`. `log(probs) / q` would be `log(probs) - log(q)`.
-        # `input / q` is fine if `input` is probs and `q` is positive.
-        # `torch.empty_like(input).exponential_(1)` generates positive values.
-
-        # Check for NaN/Inf in `input/q` before argmax if there's a concern.
-        # val = input / q
-        # if torch.isinf(val).any() or torch.isnan(val).any():
-        #     print("Warning: inf/nan encountered in multinomial sampling. Clamping might occur.")
-        #     # Handle by replacing inf with large number, nan with small, before argmax
-        #     val = torch.nan_to_num(val, nan=-torch.inf, posinf=torch.finfo(val.dtype).max, neginf=-torch.finfo(val.dtype).max)
-
-        return torch.argmax(input / q.clamp_min(1e-30), dim=-1, keepdim=True).to(torch.int64)
-
+        return torch.argmax(input / q, dim=-1, keepdim=True).to(torch.int64)
 
     input_ = input.reshape(-1, input.shape[-1])
-    # Ensure input_ to torch.multinomial is valid (non-negative, sum > 0 per row)
-    # If a row sums to 0 (e.g. all probs are 0), torch.multinomial errors.
-    # This can happen if top_k/top_p filters everything.
-    # Add a check and potentially add uniform noise if a row is all zero.
-    row_sums = input_.sum(dim=-1)
-    if torch.any(row_sums == 0):
-        # print("Warning: Zero-sum row found in multinomial input. Adding epsilon uniform distribution.")
-        # This should ideally be handled by the caller (e.g., top_k/p ensuring valid distribution)
-        # For now, if it happens, multinomial will error.
-        # A simple fix: add a tiny value to all probabilities in zero-sum rows.
-        # This is a bit of a hack; the samplers (top_p etc.) should ensure this.
-        zero_sum_rows = row_sums == 0
-        # input_[zero_sum_rows, :] = 1.0 / input_.shape[-1] # Make uniform for these rows
-        # This might not be what's intended if everything was filtered out.
-        # For now, let torch.multinomial handle it (it will error if a row sums to 0).
-        pass
-
-
     output_ = torch.multinomial(input_, num_samples=num_samples, replacement=replacement, generator=generator)
     output = output_.reshape(*list(input.shape[:-1]), -1)
     return output
@@ -88,7 +37,7 @@ def apply_unified(probs: torch.Tensor, linear: float, conf: float, quad: float) 
     Returns:
         torch.Tensor: Modified probability distribution after applying unified sampling.
     """
-    logprobs = torch.log(probs.clamp_min(1e-20)) # clamp_min to avoid log(0)
+    logprobs = torch.log(probs.clamp_min(1e-20))
     entropy = -torch.sum(probs * logprobs, dim=-1, keepdim=True)
     raw = logprobs * (linear + entropy * conf) - logprobs**2 * quad
     return raw.softmax(dim=-1)
@@ -105,24 +54,11 @@ def apply_top_k(
     Returns:
         torch.Tensor: Sampled tokens.
     """
-    if k <= 0 or k >= probs.size(-1): # if k is non-positive or covers all, no change
-        return probs
-
-    v, _ = torch.topk(probs, min(k, probs.size(-1))) # Ensure k is not out of bounds
+    v, _ = torch.topk(probs, min(k, probs.size(-1)))
     pivot = v.select(-1, -1).unsqueeze(-1)
-    probs_clone = probs.clone() # Avoid modifying original probs if it's passed around
-    probs_clone[probs_clone < pivot] = 0.0 # Zero out elements not in top-k
-
-    # Normalize
-    sum_probs = probs_clone.sum(dim=-1, keepdim=True)
-    # Avoid division by zero if sum_probs is zero (e.g., if k=1 and top prob was tiny and got zeroed somehow, or all probs were < pivot)
-    # This can happen if k is too small or probs are too flat.
-    # If sum_probs is 0, it means all probabilities were filtered. This is an issue.
-    # A robust way: if sum is 0, fall back to original probs or uniform for those rows.
-    # For now, let's assume sum_probs > 0. If not, division by zero will lead to NaNs.
-    # To prevent NaNs:
-    probs_clone = torch.where(sum_probs > 1e-9, probs_clone / sum_probs, torch.full_like(probs_clone, 1.0 / probs_clone.shape[-1])) # fallback to uniform if sum is zero
-    return probs_clone
+    probs = torch.where(probs < pivot, 0.0, probs)
+    probs.div_(probs.sum(dim=-1, keepdim=True))
+    return probs
 
 
 def apply_top_p(probs: torch.Tensor, p: float) -> torch.Tensor:
@@ -134,25 +70,13 @@ def apply_top_p(probs: torch.Tensor, p: float) -> torch.Tensor:
     Returns:
         torch.Tensor: Sampled tokens.
     """
-    if p <= 0 or p >= 1: # if p covers none or all, no change (p=0 means only top1 if strictly > p, p=1 means all)
-        if p <= 0: return probs # Or handle as "only top-1 if p=0" like some implementations
-        if p >= 1: return probs
-
     probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
     probs_sum = torch.cumsum(probs_sort, dim=-1)
-    mask = (probs_sum - probs_sort) > p # Elements to remove
-
-    probs_sort_clone = probs_sort.clone() # Avoid in-place modification issues
-    probs_sort_clone[mask] = 0.0 # Zero out elements not in top-p nucleus
-
-    # Re-scatter to original order
-    probs_out = torch.zeros_like(probs)
-    probs_out.scatter_(-1, probs_idx, probs_sort_clone)
-
-    # Normalize
-    sum_probs_out = probs_out.sum(dim=-1, keepdim=True)
-    probs_out = torch.where(sum_probs_out > 1e-9, probs_out / sum_probs_out, torch.full_like(probs_out, 1.0 / probs_out.shape[-1])) # fallback to uniform
-    return probs_out
+    mask = probs_sum - probs_sort > p
+    probs_sort *= (~mask).float()
+    probs = probs.scatter(-1, probs_idx, probs_sort)
+    probs.div_(probs.sum(dim=-1, keepdim=True))
+    return probs
 
 
 def apply_min_p(probs: torch.Tensor, min_p: float) -> torch.Tensor:
@@ -165,80 +89,42 @@ def apply_min_p(probs: torch.Tensor, min_p: float) -> torch.Tensor:
     Returns:
         torch.Tensor: Sampled tokens.
     """
-    if min_p <= 0:
-        return probs
-
     top_probs, _ = probs.max(dim=-1, keepdim=True)
     tokens_to_remove = probs < (min_p * top_probs)
-
-    probs_clone = probs.clone()
-    probs_clone[tokens_to_remove] = 0.0
-
-    sum_probs_clone = probs_clone.sum(dim=-1, keepdim=True)
-    probs_clone = torch.where(sum_probs_clone > 1e-9, probs_clone / sum_probs_clone, torch.full_like(probs_clone, 1.0 / probs_clone.shape[-1]))
-    return probs_clone
+    probs = probs.masked_fill(tokens_to_remove, 0.0)
+    probs.div_(probs.sum(dim=-1, keepdim=True))
+    return probs
 
 
 def modify_logit_for_repetition_penalty(
-    logits: torch.Tensor, # [batch_size, n_codebooks, vocab_size]
-    generated_tokens: torch.Tensor, # [batch_size, n_codebooks, seq_len]
+    logits: torch.Tensor,
+    generated_tokens: torch.Tensor,
     repetition_penalty: float,
     repetition_penalty_window: int,
 ):
     """See https://arxiv.org/abs/1909.05858
     Apply repetition penalty over a sliding window of the last `repetition_penalty_window` tokens.
+    logits: (batch_size, n_codebooks, vocab_size)
+    generated_tokens: (batch_size, n_codebooks, seq_len)
     """
-    if repetition_penalty == 1.0 or repetition_penalty_window <= 0:
-        return logits
-
-    # Consider only the last `repetition_penalty_window` tokens
-    # Ensure generated_tokens has enough history; if not, use what's available.
-    window = min(generated_tokens.shape[-1], repetition_penalty_window)
-    if window == 0: return logits # No history to penalize
-
-    tokens_in_window = generated_tokens[..., -window:] # [B, N_q, W]
-
-    # Clamp token IDs to be valid indices for logits
-    # vocab_size is logits.shape[-1]
-    vocab_size = logits.shape[-1]
-    tokens_in_window = tokens_in_window.clamp(0, vocab_size - 1)
-
-    # Create factors for penalty: initialize with 1s
-    # For each token in logits, if it appeared in `tokens_in_window`, its factor becomes `repetition_penalty`
-    # This is not quite right. We need to iterate over generated tokens and apply penalty.
-    # The original paper's formula:
-    # For positive logits, divide by penalty. For negative, multiply by penalty.
-
-    # Create a mask for tokens that appeared in the window
-    # logits_clone = logits.clone() # Work on a clone
-
-    # For each batch and codebook
-    for b_idx in range(logits.shape[0]):
-        for q_idx in range(logits.shape[1]):
-            # Get unique tokens that appeared in the window for this batch/codebook
-            unique_tokens_in_window = torch.unique(tokens_in_window[b_idx, q_idx, :])
-
-            for token_id in unique_tokens_in_window:
-                # Apply penalty to the logit of this token_id
-                current_logit = logits[b_idx, q_idx, token_id]
-                if current_logit > 0:
-                    logits[b_idx, q_idx, token_id] = current_logit / repetition_penalty
-                else:
-                    logits[b_idx, q_idx, token_id] = current_logit * repetition_penalty
-    return logits
+    generated_tokens = generated_tokens[..., -repetition_penalty_window:]
+    generated_tokens = generated_tokens.clamp_max(logits.shape[-1] - 1).to(torch.int64)
+    rp = torch.full_like(logits, repetition_penalty)
+    factors = torch.ones_like(logits).scatter_reduce(2, generated_tokens, rp, reduce="prod")
+    return torch.where(logits <= 0, logits * factors, logits / factors)
 
 
 def sample_from_logits(
-    logits: torch.Tensor, # [batch_size, num_codebooks, vocab_size]
+    logits: torch.Tensor,
     temperature: float = 1.0,
     top_p: float = 0.0,
     top_k: int = 0,
     min_p: float = 0.0,
-    linear: float = 0.0, # For unified sampler
-    conf: float = 0.0,   # For unified sampler
-    quad: float = 0.0,   # For unified sampler
-    generated_tokens: torch.Tensor | None = None, # [batch_size, num_codebooks, seq_len_generated]
-    repetition_penalty: float = 1.0, # Changed default from 3.0 to 1.0 (no penalty)
+    linear: float = 0.0,
+    conf: float = 0.0,
+    quad: float = 0.0,
+    generated_tokens: torch.Tensor | None = None,
+    repetition_penalty: float = 3.0,
     repetition_penalty_window: int = 2,
 ) -> torch.Tensor:
     """Sample next token from logits using either top_k/p/min_p OR using NovelAI's Unified Sampler.
@@ -251,6 +137,7 @@ def sample_from_logits(
 
         top_p (float): Only sample from the most probable tokens whose cumulative probability is less than p.
             This is called nucleus sampling. Must be between 0 and 1. Typical values are in the 0.1-0.9 range.
+
             Set to 0 to disable.
 
         top_k (int): Only sample from the top k most probable tokens. Set to 0 to disable.
@@ -260,56 +147,36 @@ def sample_from_logits(
                        If too high, no token might be sampled leading to silence (?)
 
         linear (float): NovelAI's Unified Sampler -> 0.0 to 1.0, default from gradio 0.5
+
             Set Linear between 0 and 1 according to how unusual you want tokens to be.
             Lower numbers will produce more unusual/creative outputs,
             but you will have to reroll or edit more.
 
         conf (float): Confidence - Low values make random outputs more random. -> -2.0 * Quad to 2.0, default from gradio 0.4
+
             As a starting point, set Quad = 1/3 - Linear * 4 / 15, and Conf = -Quad / 2.
 
         quad (float): Quadratic - High values make low probablities much lower. -> -2.0 to 2.0, default from gradio 0.0
 
     Returns:
-        torch.Tensor: Sampled tokens of shape [batch_size, num_codebooks, 1]
+        torch.Tensor: Sampled tokens.
     """
+    if repetition_penalty != 1.0 and generated_tokens is not None:
+        logits = modify_logit_for_repetition_penalty(logits, generated_tokens, repetition_penalty, repetition_penalty_window)
 
-    # Apply repetition penalty to logits first
-    if repetition_penalty != 1.0 and generated_tokens is not None and repetition_penalty_window > 0:
-        logits = modify_logit_for_repetition_penalty(
-            logits, generated_tokens, repetition_penalty, repetition_penalty_window
-        )
-
-    if temperature == 0: # Greedy sampling
-        next_token = torch.argmax(logits, dim=-1, keepdim=True)
-    else:
-        # Apply temperature
+    if temperature > 0:
         probs = torch.softmax(logits / temperature, dim=-1)
-
-        # Apply sampling strategies
-        if linear > 0.0: # NovelAI's Unified Sampler (assumes temp=1 for this path)
-            if abs(temperature - 1.0) > 1e-3 : # Check if temperature is not ~1.0
-                 print("Warning: Unified Sampler (linear > 0) is typically used with temperature=1.0.", file=sys.stderr)
+        if linear > 0.0:
             probs = apply_unified(probs, linear, conf, quad)
-
-        # These can be chained: top_k, then top_p, then min_p
+        if top_p > 0:
+            probs = apply_top_p(probs, top_p)
         if top_k > 0:
             probs = apply_top_k(probs, top_k)
-        if top_p > 0: # top_p is applied *after* top_k if both are set
-            probs = apply_top_p(probs, top_p)
-        if min_p > 0: # min_p is applied *after* top_p/top_k
+        if min_p > 0:
             probs = apply_min_p(probs, min_p)
 
-        # Ensure probabilities are still valid after filtering (e.g., sum to 1, no NaNs)
-        # This is crucial if any filter zeroed out all probabilities for a row.
-        # If a row in `probs` sums to 0, multinomial will error.
-        # A simple check: if sum is near zero, make it uniform for that row.
-        # This should ideally be handled within each apply_X function.
-        # For example, if top_k(1) is used and the top_1 prob is 0, then sum is 0.
-        row_sums = probs.sum(dim=-1, keepdim=True)
-        # If any row has all probs zeroed out by filters, fall back to uniform for that row.
-        # This prevents errors in `multinomial` and ensures sampling can proceed.
-        probs = torch.where(row_sums < 1e-9, torch.full_like(probs, 1.0 / probs.shape[-1]), probs / row_sums.clamp_min(1e-9))
-
         next_token = multinomial(probs, num_samples=1)
+    else:
+        next_token = torch.argmax(logits, dim=-1, keepdim=True)
 
-    return next_token # [batch_size, num_codebooks, 1]
+    return next_token  # [batch_size, num_codebooks, 1]

--- a/src/zonos_local_lib/speaker_cloning.py
+++ b/src/zonos_local_lib/speaker_cloning.py
@@ -330,12 +330,13 @@ class ResNet293_based(nn.Module):
         # x.unsqueeze(dim=1) changes [B, M, T] to [B, 1, M, T]
         # x is [Mel_bins, Time_frames] e.g. [80, 4], according to logs.
         # ResNet expects [Batch, Channels, Height, Width].
-        # Height = Mel_bins, Width = Time_frames. Channels = 1. Batch = 1.
-        # So, target shape is [1, 1, 80, 4].
-        x_for_resnet = x.unsqueeze(0).unsqueeze(1)
-        print(f"[DEBUG SpeakerCloning] Shape after x.unsqueeze(0).unsqueeze(1): {x_for_resnet.shape if hasattr(x_for_resnet, 'shape') else type(x_for_resnet)}") # Updated print statement
+        # x is [Batch, Mel_bins, Time_frames], e.g. [1, 80, 4086]
+        # ResNet's conv2d expects [Batch, Channels_in, Height, Width].
+        # We need to change x from [B, H, W] to [B, 1, H, W] (add a channel dim).
+        x_for_resnet = x.unsqueeze(1)
+        print(f"[DEBUG SpeakerCloning] Shape for ResNet input (x_for_resnet): {x_for_resnet.shape if hasattr(x_for_resnet, 'shape') else type(x_for_resnet)}")
 
-        x = self.front(x_for_resnet) # x_for_resnet should now be [1, 1, Mel_bins, T_frames]
+        x = self.front(x_for_resnet) # x_for_resnet should now be [B, 1, Mel_bins, T_frames]
         x = self.pooling(x) # ASP output [B, pooling.out_dim_calculated]
         if self.drop:
             x = self.drop(x)
@@ -493,8 +494,8 @@ class SpeakerEmbedding(nn.Module): # Wrapper for ResNet293_based model
         if os.path.exists(ckpt_path):
             try:
                 state_dict = torch.load(ckpt_path, map_location="cpu", weights_only=True) # Load to CPU first
-                self.model.load_state_dict(state_dict)
-                print(f"INFO: SpeakerEmbedding model loaded from {ckpt_path}")
+                self.model.load_state_dict(state_dict, strict=False) # Set strict=False
+                print(f"INFO: SpeakerEmbedding model loaded from {ckpt_path} (strict=False)")
             except Exception as e:
                 print(f"WARNING: Failed to load SpeakerEmbedding checkpoint from {ckpt_path}: {e}. Model is initialized with random weights.")
         else:
@@ -522,13 +523,25 @@ class SpeakerEmbedding(nn.Module): # Wrapper for ResNet293_based model
         return torchaudio.transforms.Resample(orig_sample_rate, target_sample_rate).to(self.target_device)
 
     def prepare_input(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
-        # wav: [B, L] or [L]
-        if wav.ndim == 1:
-            wav = wav.unsqueeze(0) # Add batch dim: [1, L]
-        if wav.shape[0] > 1 and wav.ndim == 2 : # Multi-channel audio in batch, e.g. [B, Channels, L]
-            wav = wav.mean(1) # Average channels -> [B, L]
-        elif wav.ndim > 2 : # E.g. [B, C, L]
-             wav = wav.mean(1) # Average channels
+        # wav: Can be [L], [C, L], or [B, C, L], or [B, L]
+        # Goal: Get to [B, L_mono_resampled_padded] on self.target_device
+
+        # 1. Ensure Batch dimension and monoize if multichannel
+        if wav.ndim == 1:  # [L]
+            wav = wav.unsqueeze(0).unsqueeze(0)  # -> [1, 1, L] (Batch, Channel, Length)
+        elif wav.ndim == 2: # Could be [C, L] or [B, L]
+            if wav.shape[0] > 1 and wav.shape[1] > 1024: # Heuristic: if first dim > 1 and second dim is long, assume [C,L]
+                wav = wav.mean(dim=0, keepdim=True).unsqueeze(0) # -> [1, 1, L_mono]
+            else: # Assume [B, L]
+                wav = wav.unsqueeze(1) # -> [B, 1, L]
+        elif wav.ndim == 3: # [B, C, L]
+            if wav.shape[1] > 1: # If multichannel
+                wav = wav.mean(dim=1, keepdim=True) # -> [B, 1, L_mono]
+        # Now wav should be [B, 1, L]
+
+        # Reshape to [B, L] for resampler if it was [B, 1, L]
+        if wav.ndim == 3 and wav.shape[1] == 1:
+            wav = wav.squeeze(1) # -> [B, L]
 
         # Ensure wav is on the correct device before resampling
         wav = wav.to(self.target_device)
@@ -540,13 +553,17 @@ class SpeakerEmbedding(nn.Module): # Wrapper for ResNet293_based model
         # Ensure minimum length for STFT (n_fft for logFbankCal is 512 by default)
         # This n_fft is hardcoded in logFbankCal's default.
         # If logFbankCal's n_fft changes, this might need to adapt or get n_fft from featCal.
-        min_len = 512 # Corresponds to n_fft in logFbankCal
-        if wav.shape[-1] < min_len:
-            padding_needed = min_len - wav.shape[-1]
-            wav = torch.nn.functional.pad(wav, (0, padding_needed), mode='constant', value=0)
-            # print(f"DEBUG: Padded waveform from {wav.shape[-1]-padding_needed} to {wav.shape[-1]} samples.")
+        # Ensure minimum length for STFT (n_fft for logFbankCal is 512 by default)
+        # This n_fft is hardcoded in logFbankCal's default.
+        # If logFbankCal's n_fft changes, this might need to adapt or get n_fft from featCal.
+        # min_len = 512 # Corresponds to n_fft in logFbankCal
+        # if wav.shape[-1] < min_len:
+        #     padding_needed = min_len - wav.shape[-1]
+        #     wav = torch.nn.functional.pad(wav, (0, padding_needed), mode='constant', value=0)
+        #     # print(f"DEBUG: Padded waveform from {wav.shape[-1]-padding_needed} to {wav.shape[-1]} samples.")
+        # Rely on MelSpectrogram's internal padding
 
-        return wav # wav is now [B, L_resampled_and_padded] on self.target_device
+        return wav # wav is now [B, L_resampled] on self.target_device
 
     def forward(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor: # wav: Host tensor
         # Prepare input handles device placement and resampling


### PR DESCRIPTION
- Modifies `DACAutoencoder` to use `AutoModel.from_pretrained` for loading "descript/dac_44khz", resolving direct import issues for `DacModel`.
- Improves robustness of `num_codebooks` retrieval.
- Updates padding logic in `DACAutoencoder.preprocess` to use the model's actual stride (320 for descript/dac) instead of a fixed 512.