### PR TITLE
Debug: Reduce max_new_tokens to ~1s for TTS audio diagnosis

### DIFF
--- a/src/wubu/tts/zonos_local_voice.py
+++ b/src/wubu/tts/zonos_local_voice.py
@@ -233,11 +233,11 @@ class ZonosLocalVoice(BaseTTSEngine):
             #     pass
 
             # Generation parameters (can also be from config/kwargs)
-            # TEMPORARILY REDUCED max_new_tokens FOR OOM DEBUGGING
-            short_max_new_tokens = 86 * 5  # Approx 5 seconds, was 86 * 30
-            print(f"DEBUG: Using temporarily reduced max_new_tokens: {short_max_new_tokens}")
+            # TEMPORARILY REDUCED max_new_tokens FOR OOM DEBUGGING & audio quality diagnosis
+            very_short_max_new_tokens = 86 * 1  # Approx 1 second
+            print(f"DEBUG: Using temporarily reduced max_new_tokens: {very_short_max_new_tokens}")
             gen_params = {
-                'max_new_tokens': self.config.get('max_new_tokens_temp_debug', short_max_new_tokens), # Use a temp config or the short value
+                'max_new_tokens': self.config.get('max_new_tokens_temp_debug', very_short_max_new_tokens), # Use a temp config or the short value
                 'cfg_scale': float(self.config.get('cfg_scale', 2.0)),
                 'sampling_params': self.config.get('sampling_params', dict(min_p=0.1)),
                 # 'batch_size': 1, # Inferred by Zonos model

--- a/src/zonos_local_lib/autoencoder.py
+++ b/src/zonos_local_lib/autoencoder.py
@@ -49,10 +49,7 @@ class DACAutoencoder:
             wav = wav.unsqueeze(0)
         if wav.ndim == 2:
             wav = wav.unsqueeze(1)
-<<<<<<< fix/dtype-mismatch-conditioning
 
-=======
->>>>>>> master
         if sr != self.dac_model.sample_rate:
             resampler = torchaudio.transforms.Resample(orig_freq=sr, new_freq=self.dac_model.sample_rate).to(wav.device)
             wav = resampler(wav)
@@ -67,7 +64,6 @@ class DACAutoencoder:
         _, codes, _, _, _ = self.dac_model.encode(wav.to(self.dac_model.device), n_quantizers=self.num_codebooks)
         return codes
 
-<<<<<<< fix/dtype-mismatch-conditioning
     def decode(self, codes: torch.Tensor, chunk_size_codes: int = None) -> torch.Tensor: # codes are [B, N_codebooks, T_codes]
         codes = codes.to(self.dac_model.device)
         _B, _Nq, T_codes = codes.shape # Get Batch, NumQuantizers, TimeCodes
@@ -121,15 +117,5 @@ class DACAutoencoder:
         # is managed correctly during chunked `encode` (which `compress` tries to do).
         # Since Zonos `generate` produces one long stream of codes, we are essentially
         # decoding this stream in chunks.
-=======
-    def decode(self, codes: torch.Tensor) -> torch.Tensor: # codes are [B, N_codebooks, T_codes]
-        codes = codes.to(self.dac_model.device)
-
-        # The vendored DAC.decode takes z_q (quantized latents).
-        # We get z_q from codes using self.dac_model.quantizer.from_codes
-        z_q, _, _ = self.dac_model.quantizer.from_codes(codes)
-
-        reconstructed_audio_padded = self.dac_model.decode(z_q)
->>>>>>> master
 
         return reconstructed_audio_padded.float() # Ensure float output, shape [B, 1, L]


### PR DESCRIPTION
- Further reduces `max_new_tokens` in `ZonosLocalVoice` to 86*1 (approx. 1 second).
- This is to observe how the previously noted "3 sounds" pattern in the output changes with a very short generation length, aiding in diagnosing whether the model is getting stuck or if the sound duration is proportional.