### PR TITLE
Fix: Adjust repetition penalty and Gradio CFG scale

### DIFF
--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -262,7 +262,7 @@ def build_interface():
 
             with gr.Column():
                 gr.Markdown("## Generation Parameters")
-                cfg_scale_slider = gr.Slider(1.0, 5.0, 2.0, 0.1, label="CFG Scale")
+                cfg_scale_slider = gr.Slider(1.01, 5.0, 2.0, 0.01, label="CFG Scale")
                 seed_number = gr.Number(label="Seed", value=420, precision=0)
                 randomize_seed_toggle = gr.Checkbox(label="Randomize Seed (before generation)", value=True)
 

--- a/src/zonos_local_lib/sampling.py
+++ b/src/zonos_local_lib/sampling.py
@@ -124,8 +124,8 @@ def sample_from_logits(
     conf: float = 0.0,
     quad: float = 0.0,
     generated_tokens: torch.Tensor | None = None,
-    repetition_penalty: float = 3.0,
-    repetition_penalty_window: int = 2,
+    repetition_penalty: float = 1.2,
+    repetition_penalty_window: int = 50,
 ) -> torch.Tensor:
     """Sample next token from logits using either top_k/p/min_p OR using NovelAI's Unified Sampler.
 


### PR DESCRIPTION
- Modified default repetition penalty in `sampling.py` from 3.0 to 1.2 and window from 2 to 50. This aims to reduce repetitive/noisy output by making the penalty less aggressive and giving it a longer memory.
- Changed Gradio interface's CFG scale slider to have a minimum of 1.01 instead of 1.0. This prevents users from selecting `cfg_scale=1.0`, which is not fully supported and could lead to errors or poor output. The assertion in `model.py` for `cfg_scale != 1` remains as a safeguard.