### PR TITLE
Feat: Add Zonos GUI controls and fix max_new_tokens

### DIFF
--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -262,7 +262,7 @@ def build_interface():
 
             with gr.Column():
                 gr.Markdown("## Generation Parameters")
-                cfg_scale_slider = gr.Slider(1.0, 5.0, 2.0, 0.1, label="CFG Scale")
+                cfg_scale_slider = gr.Slider(1.01, 5.0, 2.0, 0.01, label="CFG Scale")
                 seed_number = gr.Number(label="Seed", value=420, precision=0)
                 randomize_seed_toggle = gr.Checkbox(label="Randomize Seed (before generation)", value=True)
 

--- a/src/zonos_local_lib/sampling.py
+++ b/src/zonos_local_lib/sampling.py
@@ -124,8 +124,8 @@ def sample_from_logits(
     conf: float = 0.0,
     quad: float = 0.0,
     generated_tokens: torch.Tensor | None = None,
-    repetition_penalty: float = 3.0,
-    repetition_penalty_window: int = 2,
+    repetition_penalty: float = 1.2,
+    repetition_penalty_window: int = 50,
 ) -> torch.Tensor:
     """Sample next token from logits using either top_k/p/min_p OR using NovelAI's Unified Sampler.
 


### PR DESCRIPTION
- Fixed `max_new_tokens` in `ZonosLocalVoice` to default to 2580 (86*30) instead of a debug value of 86. This allows for generation of longer audio sequences.
- Added comprehensive Zonos generation parameter controls to the `ZonosDashboardWindow` in `wubu_ui.py`. This includes sliders and entries for:
    - Max New Tokens
    - CFG Scale
    - Temperature
    - Top P, Top K, Min P
    - Unified Sampler (Linear, Confidence, Quadratic)
    - Repetition Penalty & Window
- Implemented logic to load these settings from `config['zonos_settings']` when the dashboard opens, and a "Save Zonos Settings" button to update the configuration in memory (and attempt to trigger a file save via the engine).
- Modified `ZonosLocalVoice` to read these detailed parameters from `config['zonos_settings']` and pass them to the `Zonos.generate()` method, allowing for fine-grained control over the TTS synthesis process via the WuBu GUI.